### PR TITLE
G is a horrible letter. That's why Hlanq shouldn't let people run code with G's in it.

### DIFF
--- a/hl/interpreter.cr
+++ b/hl/interpreter.cr
@@ -86,6 +86,8 @@ class HL::Interpreter
         when '^' then @stack.delete_at(@r) if @stack.size > @r
         when '[' then @ignore += 1_i64 if @r == 0 || @ignore > 0
         when ']' then @ignore -= 1_i64 if @ignore > 0
+        when 'g' then raise "Please remove any g letters in your code. It's for your safety."
+        when 'G' then raise "Please remove any G letters in your code. It's for your safety."
         end
 
         @i += 1_i64


### PR DESCRIPTION
Hlanq is an innovative proqramminq lanquaqe written with very best effort to make it stable and fast.
Because every year letter G kills about 420 people I decided to protect people from that letter in Hlanq.
That's why I implemented this simple and very short piece of code:
```crystal
when 'g' then raise "Please remove any g letters in your code. It's for your safety."
when 'G' then raise "Please remove any G letters in your code. It's for your safety."
```
We should use technoloqy for people safety.
I believe that this will save lives of milions of people. As developers we should strive to protect people from any danqer. No matter if they are at risk of prolonqed exposure to letter G or other less important thinqs.
